### PR TITLE
Add build logs for securedrop-workstation-dom0-config 0.7.1

### DIFF
--- a/workstation/securedrop-workstation-dom0-config-0.7.1
+++ b/workstation/securedrop-workstation-dom0-config-0.7.1
@@ -1,0 +1,122 @@
+$ make dom0-rpm
+Removing dist/
+running sdist
+running egg_info
+creating securedrop_workstation_dom0_config.egg-info
+writing securedrop_workstation_dom0_config.egg-info/PKG-INFO
+writing dependency_links to securedrop_workstation_dom0_config.egg-info/dependency_links.txt
+writing top-level names to securedrop_workstation_dom0_config.egg-info/top_level.txt
+writing manifest file 'securedrop_workstation_dom0_config.egg-info/SOURCES.txt'
+reading manifest file 'securedrop_workstation_dom0_config.egg-info/SOURCES.txt'
+reading manifest template 'MANIFEST.in'
+writing manifest file 'securedrop_workstation_dom0_config.egg-info/SOURCES.txt'
+running check
+creating securedrop-workstation-dom0-config-0.7.1
+creating securedrop-workstation-dom0-config-0.7.1/dom0
+creating securedrop-workstation-dom0-config-0.7.1/launcher
+creating securedrop-workstation-dom0-config-0.7.1/launcher/sdw_notify
+creating securedrop-workstation-dom0-config-0.7.1/launcher/sdw_updater_gui
+creating securedrop-workstation-dom0-config-0.7.1/launcher/sdw_util
+creating securedrop-workstation-dom0-config-0.7.1/scripts
+creating securedrop-workstation-dom0-config-0.7.1/sd-app
+creating securedrop-workstation-dom0-config-0.7.1/sd-proxy
+creating securedrop-workstation-dom0-config-0.7.1/sd-whonix
+creating securedrop-workstation-dom0-config-0.7.1/sd-workstation
+creating securedrop-workstation-dom0-config-0.7.1/securedrop_workstation_dom0_config.egg-info
+creating securedrop-workstation-dom0-config-0.7.1/sys-firewall
+creating securedrop-workstation-dom0-config-0.7.1/usb-autoattach
+copying files to securedrop-workstation-dom0-config-0.7.1...
+copying LICENSE -> securedrop-workstation-dom0-config-0.7.1
+copying MANIFEST.in -> securedrop-workstation-dom0-config-0.7.1
+copying README.md -> securedrop-workstation-dom0-config-0.7.1
+copying VERSION -> securedrop-workstation-dom0-config-0.7.1
+copying config.json.example -> securedrop-workstation-dom0-config-0.7.1
+copying pyproject.toml -> securedrop-workstation-dom0-config-0.7.1
+copying setup.py -> securedrop-workstation-dom0-config-0.7.1
+copying dom0/dom0-xfce-desktop-file.j2 -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/fpf-apt-repo.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/remove-tags -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-app-config.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-app-files.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-app.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-clean-all.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-clean-default-dispvm.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-default-config.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-default-config.yml -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-devices-files.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-devices.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-dom0-crontab.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-dom0-files.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-dom0-qvm-rpc.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-dom0-systemd.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-gpg-files.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-gpg.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-log.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-logging-setup.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-mime-handling.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-proxy-files.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-proxy-template-files.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-proxy.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-remove-unused-templates.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-rsyslog.conf.j2 -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-sys-vms.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-sys-whonix-vms.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-upgrade-templates.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-usb-autoattach-add.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-usb-autoattach-remove.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-viewer-files.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-viewer.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-whonix-hidserv-key.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-whonix.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-workstation-template-files.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-workstation-template.sls -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sd-workstation.top -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/sdlog.conf -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/securedrop-check-migration -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/securedrop-handle-upgrade -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/securedrop-launcher.desktop -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/securedrop-login -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying dom0/update-xfce-settings -> securedrop-workstation-dom0-config-0.7.1/dom0
+copying launcher/sdw-launcher.py -> securedrop-workstation-dom0-config-0.7.1/launcher
+copying launcher/sdw-notify.py -> securedrop-workstation-dom0-config-0.7.1/launcher
+copying launcher/sdw_notify/Notify.py -> securedrop-workstation-dom0-config-0.7.1/launcher/sdw_notify
+copying launcher/sdw_notify/NotifyApp.py -> securedrop-workstation-dom0-config-0.7.1/launcher/sdw_notify
+copying launcher/sdw_notify/strings.py -> securedrop-workstation-dom0-config-0.7.1/launcher/sdw_notify
+copying launcher/sdw_updater_gui/Updater.py -> securedrop-workstation-dom0-config-0.7.1/launcher/sdw_updater_gui
+copying launcher/sdw_updater_gui/UpdaterApp.py -> securedrop-workstation-dom0-config-0.7.1/launcher/sdw_updater_gui
+copying launcher/sdw_updater_gui/UpdaterAppUiQt5.py -> securedrop-workstation-dom0-config-0.7.1/launcher/sdw_updater_gui
+copying launcher/sdw_updater_gui/strings.py -> securedrop-workstation-dom0-config-0.7.1/launcher/sdw_updater_gui
+copying launcher/sdw_util/Util.py -> securedrop-workstation-dom0-config-0.7.1/launcher/sdw_util
+copying scripts/clean-salt -> securedrop-workstation-dom0-config-0.7.1/scripts
+copying scripts/configure-environment -> securedrop-workstation-dom0-config-0.7.1/scripts
+copying scripts/destroy-vm -> securedrop-workstation-dom0-config-0.7.1/scripts
+copying scripts/lint-all -> securedrop-workstation-dom0-config-0.7.1/scripts
+copying scripts/provision-all -> securedrop-workstation-dom0-config-0.7.1/scripts
+copying scripts/sdw-admin.py -> securedrop-workstation-dom0-config-0.7.1/scripts
+copying scripts/validate_config.py -> securedrop-workstation-dom0-config-0.7.1/scripts
+copying sd-app/config.json.j2 -> securedrop-workstation-dom0-config-0.7.1/sd-app
+copying sd-proxy/mimeapps.list -> securedrop-workstation-dom0-config-0.7.1/sd-proxy
+copying sd-proxy/sd-proxy.yaml -> securedrop-workstation-dom0-config-0.7.1/sd-proxy
+copying sd-whonix/app-journalist.yaml -> securedrop-workstation-dom0-config-0.7.1/sd-whonix
+copying sd-workstation/apt-test-pubkey.asc -> securedrop-workstation-dom0-config-0.7.1/sd-workstation
+copying sd-workstation/logo-small.png -> securedrop-workstation-dom0-config-0.7.1/sd-workstation
+copying sd-workstation/securedrop-release-signing-pubkey-2021.asc -> securedrop-workstation-dom0-config-0.7.1/sd-workstation
+copying securedrop_workstation_dom0_config.egg-info/PKG-INFO -> securedrop-workstation-dom0-config-0.7.1/securedrop_workstation_dom0_config.egg-info
+copying securedrop_workstation_dom0_config.egg-info/SOURCES.txt -> securedrop-workstation-dom0-config-0.7.1/securedrop_workstation_dom0_config.egg-info
+copying securedrop_workstation_dom0_config.egg-info/dependency_links.txt -> securedrop-workstation-dom0-config-0.7.1/securedrop_workstation_dom0_config.egg-info
+copying securedrop_workstation_dom0_config.egg-info/top_level.txt -> securedrop-workstation-dom0-config-0.7.1/securedrop_workstation_dom0_config.egg-info
+copying sys-firewall/sd-copy-rpm-repo-pubkey.sh -> securedrop-workstation-dom0-config-0.7.1/sys-firewall
+copying usb-autoattach/99-sd-devices.rules -> securedrop-workstation-dom0-config-0.7.1/usb-autoattach
+copying usb-autoattach/sd-attach-export-device -> securedrop-workstation-dom0-config-0.7.1/usb-autoattach
+Writing securedrop-workstation-dom0-config-0.7.1/setup.cfg
+creating dist
+Creating tar archive
+removing 'securedrop-workstation-dom0-config-0.7.1' (and everything under it)
+warning: no previously-included files found matching 'scripts/build-dom0-rpm'
+warning: no previously-included files found matching 'scripts/clone-to-dom0'
+warning: no previously-included files found matching 'scripts/prep-dev'
+warning: File listed twice: /usr/share/securedrop-workstation-dom0-config/config.json.example
+
+Build complete! RPMs and their checksums are:
+
+96f404e05940e3cb44e1074264195d5c85d29cc3fa4fac73f0121c55e00f4d01  rpm-build/RPMS/noarch/securedrop-workstation-dom0-config-0.7.1-1.fc32.noarch.rpm


### PR DESCRIPTION
Add build logs for **securedrop-workstation-dom0-config-0.7.1**.

Context: https://github.com/freedomofpress/securedrop-workstation/pull/845

:pear: @eaon 